### PR TITLE
Enabling default encryption for Amazon DocumentDB

### DIFF
--- a/blogs/appsync-docdb/template.yml
+++ b/blogs/appsync-docdb/template.yml
@@ -123,6 +123,7 @@ Resources:
       MasterUserPassword: !Sub "${DocDbpassword}"
       EngineVersion: 4.0.0
       DBSubnetGroupName: !Ref BlogDBSubnetGroup
+      StorageEncrypted : true
       VpcSecurityGroupIds:
       - Fn::GetAtt:
             - BlogDocdbSg


### PR DESCRIPTION
Enabling default encryption for Amazon DocumentDB in response to AppSec ticket https://t.corp.amazon.com/V498355357/overview